### PR TITLE
feat(HGI-10569) Target-Quickbooks-v2 (v2 branch) migrate to HotglueSi…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,8 @@ license = "Apache 2.0"
 [tool.poetry.dependencies]
 python = "<3.11,>=3.7.1"
 requests = "^2.25.1"
-singer-sdk = "^0.9.0"
 intuit-oauth = "^1.2.4"
-target-hotglue = "^0.1.6"
+hotglue-singer-sdk = "^1.0.36"
 hotglue-models-accounting = { git = "https://gitlab.com/hotglue/hotglue-models-accounting.git", rev = "v2" }
 
 [tool.poetry.dev-dependencies]

--- a/target_quickbooks/base_sinks.py
+++ b/target_quickbooks/base_sinks.py
@@ -1,12 +1,11 @@
 import json
-from copy import deepcopy
-from typing import Dict, List, Optional, Any
 import os
+from copy import deepcopy
+from typing import Any, Dict, List, Optional
 
-from singer_sdk.plugin_base import PluginBase
+from hotglue_singer_sdk.plugin_base import PluginBase
+from hotglue_singer_sdk.target_sdk.client import HotglueBatchSink
 
-from target_hotglue.client import HotglueBatchSink
-from target_hotglue.client import HotglueBatchSink
 from target_quickbooks.quickbooks_client import QuickbooksClient
 
 

--- a/target_quickbooks/lambda.py
+++ b/target_quickbooks/lambda.py
@@ -2,6 +2,7 @@ import importlib
 from logging import Logger
 from typing import Optional
 
+
 def real_time_handler(
     config: dict,
     stream_name: str,
@@ -11,7 +12,7 @@ def real_time_handler(
     input_path: Optional[str] = None,
 ):
     try:
-        mod = importlib.import_module("target_hotglue.lambda")
+        mod = importlib.import_module("hotglue_singer_sdk.target_sdk.lambda")
 
         if not hasattr(mod, "real_time_handler"):
             raise Exception("This target does not support real time")

--- a/target_quickbooks/target.py
+++ b/target_quickbooks/target.py
@@ -1,20 +1,22 @@
 """QuickBooks target class."""
 
-from singer_sdk import typing as th
-from target_hotglue.target import TargetHotglue
+import atexit
+
+from hotglue_singer_sdk import typing as th
+from hotglue_singer_sdk.target_sdk.target import TargetHotglue
+
 from target_quickbooks.quickbooks_client import QuickbooksClient
-from target_quickbooks.sinks.bill_sink import BillSink
 from target_quickbooks.sinks.bill_payment_sink import BillPaymentSink
+from target_quickbooks.sinks.bill_sink import BillSink
 from target_quickbooks.sinks.customer_sink import CustomerSink
-from target_quickbooks.sinks.invoice_sink import InvoiceSink
 from target_quickbooks.sinks.invoice_payment_sink import InvoicePaymentSink
+from target_quickbooks.sinks.invoice_sink import InvoiceSink
 from target_quickbooks.sinks.item_sink import ItemSink
 from target_quickbooks.sinks.journal_entry_sink import JournalEntrySink
 from target_quickbooks.sinks.purchase_order_sink import PurchaseOrderSink
-from target_quickbooks.sinks.vendor_sink import VendorSink
 from target_quickbooks.sinks.vendor_credit_sink import VendorCreditSink
+from target_quickbooks.sinks.vendor_sink import VendorSink
 from target_quickbooks.util import cleanup
-import atexit
 
 
 class TargetQuickBooks(TargetHotglue):

--- a/target_quickbooks/tests/test_core.py
+++ b/target_quickbooks/tests/test_core.py
@@ -1,10 +1,9 @@
 """Tests standard target features using the built-in SDK tests library."""
 
 import datetime
+from typing import Any, Dict
 
-from typing import Dict, Any
-
-from singer_sdk.testing import get_standard_target_tests
+from hotglue_singer_sdk.testing import get_standard_target_tests
 
 from target_quickbooks.target import TargetQuickBooks
 


### PR DESCRIPTION
## Summary
- Replaced the `target-hotglue` dependency with `hotglue-singer-sdk = "^1.0.36"` and removed the direct `singer-sdk` dependency.
- Migrated SDK imports from `target_hotglue` and direct `singer_sdk` paths to `hotglue_singer_sdk` / `hotglue_singer_sdk.target_sdk`.
- Updated the Lambda dynamic import and SDK test import path.
- Removed the duplicate `HotglueBatchSink` import and ran `isort` on the touched files.

## Verification
- Scanned first-party source/config/docs for stale `target_hotglue`, `target-hotglue`, direct `singer_sdk`, and `singer-sdk` references. No stale first-party references remain, other than the expected `hotglue-singer-sdk` dependency name.
- Installed `hotglue-singer-sdk==1.0.36` locally and verified migrated SDK import paths.
- Ran Python compile checks for touched package files.
- Imported touched project modules successfully.
- Ran `isort --check-only` successfully on touched files.

## Notes
- `pytest` currently fails during collection because `target_quickbooks/tests/conftest.py` imports missing `target_quickbooks.client`, which appears to be an existing stale test issue unrelated to this migration.
- `black --check` and `flake8` report existing formatting/lint issues in touched files; these were not broadened into this SDK migration to keep the change minimal.